### PR TITLE
[Fix] 이메일 인증 로직 수정 (회원가입 및 회원정보 수정 관련)

### DIFF
--- a/src/main/java/org/spring/dojooo/auth/Redis/RedisUtil.java
+++ b/src/main/java/org/spring/dojooo/auth/Redis/RedisUtil.java
@@ -28,12 +28,14 @@ public class RedisUtil {
         log.info("RedisUtil 초기화됨: RedisTemplate = {}", redisTemplate);
     }
 
+    //이메일 인증 코드
     public void saveEmailCode(String email, String code) {
         log.info("Redis 저장 시도 - email: {}, code: {}", email,code);
+        redisTemplate.opsForValue().set("emailCode:" + email,code,Duration.ofMinutes(5)); //5분 유효 (이메일을 5분안에 입력해야함.)
     }
     //유효 검증
     public void saveVerifiedEmail(String email) {
-        redisTemplate.opsForValue().set("verified:" + email, "true", Duration.ofMinutes(10));  // 10분 유효
+        redisTemplate.opsForValue().set("verified:" + email, "true", Duration.ofMinutes(10));  // 10분 유효 (10분안에 회원가입을 완료해야함)
     }
 
     public boolean isVerifiedEmail(String email) {
@@ -41,21 +43,27 @@ public class RedisUtil {
         return "true".equals(result);
     }
 
-
     public String getEmailCode(String email) {
-        return redisTemplate.opsForValue().get(email);
+        return redisTemplate.opsForValue().get("emailCode:" + email);
     }
 
     public void deleteEmailCode(String email) {
-        redisTemplate.delete(email);
+        redisTemplate.delete("emailCode:"+ email);
     }
+
+    public void deleteVerifiedEmail(String email) {
+        redisTemplate.delete("verified:" + email);
+    }
+
     public void saveRefreshToken(String username, String refreshToken) {
         log.info("Redis 저장 시도 - user: {}. refreshToken: {}", username, refreshToken);
-        redisTemplate.opsForValue().set("refresh:" + username,refreshToken);
+        redisTemplate.opsForValue().set("refresh:" + username,refreshToken,Duration.ofMinutes(30)); //30분 RefreshToken 유효하게 설정
     }
+
     public String getRefreshToken(String username) {
         return redisTemplate.opsForValue().get("refresh:" + username);
     }
+
     public void deleteRefreshToken(String username) {
         redisTemplate.delete("refresh:" + username);
     }

--- a/src/main/java/org/spring/dojooo/auth/jwt/controller/ReissueController.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/controller/ReissueController.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.auth.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.config.JWTUtil;
 
-import org.spring.dojooo.main.users.repository.UserRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReissueController {
     private final JWTUtil jwtUtil;
     private final RedisUtil redisUtil;
-    private final UserRepository userRepository;
 
     @Operation(summary = "AccessToken 재발급",description = "Access Token 만료시")
     @PostMapping("/reissue")
@@ -74,7 +72,7 @@ public class ReissueController {
         //Access 생성
         String newAccess = jwtUtil.createJwt("access", email, role, 600000L);
         //Refresh 생성 (Refresh Rotate)-Access +  Refresh 재발급
-        String newRefresh = jwtUtil.createJwt("refresh", email, role, 1800000L); //30qns
+        String newRefresh = jwtUtil.createJwt("refresh", email, role, 1800000L); //30 -> JWT 내부의 만료시간
 
         redisUtil.saveRefreshToken(email, newRefresh);
         response.setHeader("access", newAccess);

--- a/src/main/java/org/spring/dojooo/auth/mail/controller/EmailController.java
+++ b/src/main/java/org/spring/dojooo/auth/mail/controller/EmailController.java
@@ -1,12 +1,16 @@
 package org.spring.dojooo.auth.mail.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.auth.Redis.RedisUtil;
 import org.spring.dojooo.auth.mail.dto.EmailMessage;
 import org.spring.dojooo.auth.mail.dto.EmailPost;
 import org.spring.dojooo.auth.mail.dto.EmailResponse;
 import org.spring.dojooo.auth.mail.dto.EmailVerifyRequest;
 import org.spring.dojooo.auth.mail.service.EmailService;
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.ApiException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,10 +21,13 @@ import java.time.Duration;
 @RestController
 @RequestMapping("/send-mail")
 @RequiredArgsConstructor
+@Slf4j
 public class EmailController {
     private final EmailService emailService;
     private final RedisUtil redisUtil;
+
     //이메일 인증을 위한 인증코드 발송 코드
+    @Operation(summary = "이메일 인증 코드 전송", description = "5분간 유효한 이메일 인증 코드를 전송합니다.")
     @PostMapping("/email")
     public ResponseEntity sendJoinMail(@RequestBody EmailPost emailPost) {
         EmailMessage emailMessage = EmailMessage.builder()
@@ -28,7 +35,7 @@ public class EmailController {
                 .subject("[dojooo] 이메일 인증을 위한 인증 코드 발송")
                 .build();
         String code = emailService.sendMail(emailMessage, "email");
-        redisUtil.saveEmailCode(emailPost.getEmail(), code);
+        redisUtil.saveEmailCode(emailPost.getEmail(), code); //5분간 유효한
 
         EmailResponse emailResponse = EmailResponse.builder()
                 .code(code)
@@ -36,23 +43,34 @@ public class EmailController {
                 .build();
         return ResponseEntity.ok(emailResponse);
     }
+
     //인증 코드 검증
+    @Operation(summary = "이메일 인증 코드 검증", description = "전송된 인증 코드와 입력값을 비교하여 인증합니다. 인증에 성공하면 10분 이내에 회원가입을 완료해야 합니다.")
     @PostMapping("/verify")
     public ResponseEntity<?> verifyEmail(@RequestBody EmailVerifyRequest request) {
         String emailCode = redisUtil.getEmailCode(request.getEmail());
+
         if (emailCode == null) {
-            return ResponseEntity.badRequest().body("인증번호가 만료되었거나 존재하지 않습니다.");
+            log.warn("인증 코드 없음 또는 만료됨 - email: {}", request.getEmail());
+            throw new ApiException(ErrorCode.EMAIL_CODE_EXPIRED); //이메일 인증이 만료된경우 *5분
         }
 
-        if (!emailCode.equals(request.getCode())) {
-            return ResponseEntity.badRequest().body("인증번호가 일치하지 않습니다.");
+        if (!emailCode.equals(request.getCode().trim())) {
+            log.warn("인증 코드 불일치 - email: {}, 입력된 코드: {}", request.getEmail(), request.getCode());
+            throw new ApiException(ErrorCode.EMAIL_CODE_NOT_MATCH); //이메일 인증 코드가 일치하지않는 경우
         }
         //인증 성공 -> 인증 완료 표시 저장
-        redisUtil.saveVerifiedEmail(request.getEmail());
+        try {
+            // 인증 성공 -> 인증 완료 표시 저장
+            redisUtil.saveVerifiedEmail(request.getEmail());
+            // 인증 완료되면 코드 제거
+            redisUtil.deleteEmailCode(request.getEmail());
+        } catch (Exception e) {
+            log.error("Redis 처리 중 오류 - email: {}", request.getEmail(), e);
+            throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
 
-        // 인증 완료되면 제거
-        redisUtil.deleteEmailCode(request.getEmail());
-
+        log.info("이메일 인증 성공 - email: {}", request.getEmail());
         return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
     }
 }

--- a/src/main/java/org/spring/dojooo/auth/mail/service/EmailService.java
+++ b/src/main/java/org/spring/dojooo/auth/mail/service/EmailService.java
@@ -22,7 +22,6 @@ import java.util.Random;
 public class EmailService {
     private final JavaMailSender javaMailSender;
 
-    private final UserService userService;
     private final RedisTemplate<String, String> redisTemplate;
     private final SpringTemplateEngine templateEngine;
 
@@ -36,8 +35,7 @@ public class EmailService {
                 mimeMessage.setText("인증번호: " + authNum, "utf-8");
                 javaMailSender.send(mimeMessage);
 
-                // 인증번호 Redis에 저장 (5분 유효)
-                redisTemplate.opsForValue().set(emailMessage.getTo(), authNum, Duration.ofMinutes(5));
+                redisTemplate.opsForValue().set("emailCode:" + emailMessage.getTo(), authNum, Duration.ofMinutes(5));
             }
         } catch (MessagingException e) {
             log.error("메일 전송 실패", e);

--- a/src/main/java/org/spring/dojooo/global/ErrorCode.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorCode.java
@@ -14,6 +14,9 @@ public enum ErrorCode {
     CONFLICT_ERROR("중복된 값입니다.", 409),
 
     EMAIL_BAD_REQUEST("이메일 인증이 완료되지 못했습니다", 401),
+    EMAIL_AUTH_TIMEOUT("이메일 인증 시간이 만료되었습니다. 다시 인증해주세요",401),
+    EMAIL_CODE_EXPIRED("인증번호가 만료되었거나 존재하지 않습니다.", 400),
+    EMAIL_CODE_NOT_MATCH("인증번호가 일치하지 않습니다.", 400),
 
     DUPLICATE_USER("이미 가입되어 있는 사용자 입니다", 409),
     NOT_FOUND_USER("사용자를 찾을 수 없습니다", 404),

--- a/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package org.spring.dojooo.global;
 
 import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.auth.jwt.exception.InvalidTokenException;
+import org.spring.dojooo.global.exception.ApiException;
 import org.spring.dojooo.global.exception.NotFoundException;
 import org.spring.dojooo.main.users.exception.DuplicateUserException;
 import org.spring.dojooo.main.users.exception.NotFoundUserException;
@@ -21,7 +22,11 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
-
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleApiException(ApiException exception) {
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
             MethodArgumentNotValidException exception

--- a/src/main/java/org/spring/dojooo/global/exception/ApiException.java
+++ b/src/main/java/org/spring/dojooo/global/exception/ApiException.java
@@ -13,4 +13,5 @@ public class ApiException extends RuntimeException {
   public ErrorCode getErrorCode() {
     return errorCode;
   }
+
 }

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
     private final RedisUtil redisUtil;
 
     //회원가입 요청
-    @Operation(summary = "회원가입", description = "회원 가입 정보를 전달받아 회원 가입 합니다")
+    @Operation(summary = "회원가입", description = "회원가입은 이메일 인증 후 10분 이내에 완료되어야 하며, 이메일 인증 코드는 발송 후 5분 이내에 입력해야 유효합니다.")
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Long>> createUser(@Validated @RequestBody UserSignUpRequest userSignUpRequest) {
         log.info("회원가입 성공");


### PR DESCRIPTION
### 기존 이메일 인증 로직 문제점

- 기존 로직 흐름:
이메일 전송 → 인증 → 인증 완료 상태 Redis 저장 → 인증 완료 상태 확인 후 회원가입 → Refresh Token 발급
- 문제 발생:
    - 완료 상태가 Redis에 영구적으로 저장되어 삭제되지 않음
    - 회원정보 수정 시에도 이메일 인증을 하면 인증 완료 상태가 계속 남아 있음

### 문제점 해결

- 기존 로직 수정:
이메일 전송 → 인증 코드 Redis에 5분간 저장 → 인증 성공 시 인증 코드 제거 + 인증 완료 상태 10분간 저장 → 회원가입 완료 시 인증 완료 상태 제거 및 Refresh Token 발급
- 로직 변경 핵심:
    - 인증 완료 상태는 10분간만 유지, 이후 자동 만료
    - 인증 코드는 5분 이내 인증 필요, 미인증 시 만료 처리
    - 회원가입이 완료되면 인증 완료 상태도 삭제하여 보안성 유지