### PR TITLE
[Feat] 회원 로그아웃 기능 구현 및 회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/org/spring/dojooo/auth/jwt/filter/JWTFilter.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/filter/JWTFilter.java
@@ -13,11 +13,9 @@ import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
 import org.spring.dojooo.auth.jwt.security.CustomUserDetailsService;
 import org.spring.dojooo.global.ErrorCode;
 import org.spring.dojooo.main.users.domain.User;
-import org.spring.dojooo.main.users.model.Role;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -32,6 +30,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("[JWTFilter] 요청 URI: {}", request.getRequestURI());
         String authorization = request.getHeader(AUTH_HEADER);
 
         if (authorization == null || !authorization.startsWith(BEARER)) {

--- a/src/main/java/org/spring/dojooo/auth/jwt/security/SecurityConfig.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/security/SecurityConfig.java
@@ -17,7 +17,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/org/spring/dojooo/main/users/service/UserService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/UserService.java
@@ -1,9 +1,9 @@
 package org.spring.dojooo.main.users.service;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.auth.jwt.security.CustomUserDetailsService;
 import org.spring.dojooo.global.ErrorCode;
 import org.spring.dojooo.global.exception.ApiException;
 import org.spring.dojooo.main.users.domain.User;
@@ -25,8 +25,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper;
-
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Transactional
     public Long saveUser(UserSignUpRequest userSignUpRequest) {
@@ -79,6 +78,14 @@ public class UserService {
         user.updateUser(userUpdateRequest);
         return user.getId();
     }
+    //회원 탈퇴
+    @Transactional
+    public Long deleteUser(Long id) {
+        User user = findActiveUser(id); //회원 조회
+        //refresh Token 삭제
+        redisUtil.deleteRefreshToken( user.getEmail());
+        return user.getId();
+    }
 
     //DB에 존재하는 회원인지 아닌지 확인(회원 조회)
     @Transactional(readOnly = true)
@@ -86,6 +93,8 @@ public class UserService {
         return userRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
     }
+
+
 
 
 


### PR DESCRIPTION
### 회원 로그아웃 기능 구현
- 로그인한 회원이 로그아웃 요청 시, 클라이언트 측에서는 로컬 캐시에 저장된 JWT를 제거함
- 하지만 서버에서는 해당 JWT를 직접 무효화할 수 있는 수단이 없으므로, 일반적으로는 로그아웃된 JWT를 블랙리스트(예: Redis, DB 등)에 저장하여 관리
- 이후 사용자의 인가 요청 시, 해당 JWT가 블랙리스트에 존재하는지를 확인하여 로그아웃 여부를 판단할 수 있음
- **블랙리스트 방식은 JWT의 Stateless 하지 못함으로*, 아래와 같이 구현.
    - Redis에서 Refresh Token을 삭제하여, 로그아웃한 사용자가 더 이상 새로운 Access Token을 발급받지 못하도록 함
    - Access Token의 유효기간을 짧게 설정하여, 만약 토큰이 유출되더라도 보안 피해를 최소화
- Spring Security의 기본 로그아웃 필터는 사용하지 않고, **Controller 레벨에서 직접 로그아웃 처리를 수행하는 커스텀 API 방식**으로 구현

### 회원 탈퇴 기능 구현

- 회원 탈퇴 시, Redis에서 해당 사용자의 Refresh Token을 제거하여 Access Token 재발급을 차단
- DB에서는 해당 회원을 물리적으로 삭제하지 않고, `is_deleted = true`로 설정하는 논리적 삭제 방식을 적용
- 이후 사용자 조회 등 서비스 이용 시, 아래 조건을 통해 탈퇴 여부를 판단하여 서비스 이용을 차단
```java
//UserRepository.java
Optional<User> findByIdAndIsDeletedFalse(Long id);
```
- 이를 통해 탈퇴한 사용자는 시스템 전반에서 더 이상 유효한 사용자로 인식되지 않음