### PR TITLE
[Feat] S3 환경 설정 및 프로필 사진 등록기능 구현

### DIFF
--- a/.github/workflows/Dojooo_CI.yml
+++ b/.github/workflows/Dojooo_CI.yml
@@ -43,4 +43,11 @@ jobs:
 
             # 5. 최신 Docker 이미지 Pull 및 실행
             docker pull ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/dojooo:latest
-            docker run -d --name dojooo-container -p 8080:8080 ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/dojooo:latest
+            docker run -d --name dojooo-container -p 8080:8080 \
+              -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+              -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+              -e S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }} \
+              -e spring.jwt.secret=${{ secrets.SPRING_JWT_SECRET}} \
+              -e mail.username=${{ secrets.MAIL_USERNAME }} \
+              -e mail.password=${{ secrets.MAIL_PASSWORD }} \
+            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/dojooo:latest

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6' // JSON 처리 라이브러리
 
+	//S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/spring/dojooo/Image/Service/ImageService.java
+++ b/src/main/java/org/spring/dojooo/Image/Service/ImageService.java
@@ -1,0 +1,52 @@
+package org.spring.dojooo.Image.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.spring.dojooo.Image.domain.Image;
+import org.spring.dojooo.Image.repository.ImageRepository;
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.S3.S3FileService;
+import org.spring.dojooo.main.users.domain.User;
+import org.spring.dojooo.main.users.exception.NotFoundUserException;
+import org.spring.dojooo.main.users.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+    private final ImageRepository imageRepository;
+    private final S3FileService s3Uploader;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public String uploadProfileImage(MultipartFile file,String email) throws IOException {
+        //이메일로 유저 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(()-> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        //기존에 등록되어 있는 이미지가 있는지 => 있으면 삭제 (새로 업데이트 하기 위해서)
+        imageRepository.findByUserId(user.getId())
+                .ifPresent(oldImage -> {
+                    s3Uploader.deleteImageFromS3(oldImage.getUrl()); //S3에서 삭제
+                    imageRepository.delete(oldImage);//Repository 에서 삭제
+                });
+        //S3에 이미지 업로드
+        String uploadedUrl = s3Uploader.upload(file,"profile");//profile/--
+
+        //Image 엔티티 저장
+        Image image = Image.builder()
+                .fileName(file.getOriginalFilename())
+                .url(uploadedUrl)
+                .user(user)
+                .build();
+
+        //Repository 저장
+        imageRepository.save(image);
+
+        return uploadedUrl;
+
+    }
+
+}

--- a/src/main/java/org/spring/dojooo/Image/controller/ImageController.java
+++ b/src/main/java/org/spring/dojooo/Image/controller/ImageController.java
@@ -1,0 +1,41 @@
+package org.spring.dojooo.Image.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.spring.dojooo.Image.Service.ImageService;
+import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
+import org.spring.dojooo.global.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @Operation(summary = "프로필 사진 업로드", description = "사용자가 마이페이지에서 프로필 사진을 등록할 수 있습니다")
+    @PostMapping("/users/profile/images")
+    public ResponseEntity<ApiResponse<String>> uploadProfileImage(@RequestParam("file") MultipartFile file, Authentication authentication) throws IOException {
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal(); //현재 로그인한 사용자의 정보 추출
+        String email = userDetails.getUsername();
+
+        log.info("프로필 이미지 업로드 - 사용자: {}", email);
+        String url = imageService.uploadProfileImage(file, email);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(201, "프로필 사진 업로드가 완료되었습니다", url));
+    }
+
+}

--- a/src/main/java/org/spring/dojooo/Image/domain/Image.java
+++ b/src/main/java/org/spring/dojooo/Image/domain/Image.java
@@ -1,0 +1,36 @@
+package org.spring.dojooo.Image.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.spring.dojooo.main.users.domain.User;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name="image")
+
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="image_id")
+    private Long id;
+
+    @Column(name="file_name")
+    private String fileName;
+
+    @Column(nullable = false)
+    private String url;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public void updateUrl(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/org/spring/dojooo/Image/repository/ImageRepository.java
+++ b/src/main/java/org/spring/dojooo/Image/repository/ImageRepository.java
@@ -1,0 +1,12 @@
+package org.spring.dojooo.Image.repository;
+
+import org.spring.dojooo.Image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByUserId(Long userId);
+}

--- a/src/main/java/org/spring/dojooo/auth/jwt/controller/ReissueController.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/controller/ReissueController.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.config.JWTUtil;
 
 import org.springframework.http.HttpStatus;

--- a/src/main/java/org/spring/dojooo/auth/jwt/filter/LoginFilter.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/filter/LoginFilter.java
@@ -5,7 +5,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.config.JWTUtil;
 import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
 import org.spring.dojooo.global.ErrorCode;

--- a/src/main/java/org/spring/dojooo/auth/jwt/security/SecurityConfig.java
+++ b/src/main/java/org/spring/dojooo/auth/jwt/security/SecurityConfig.java
@@ -2,7 +2,7 @@ package org.spring.dojooo.auth.jwt.security;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.config.JWTUtil;
 import org.spring.dojooo.auth.jwt.filter.JWTFilter;
 import org.spring.dojooo.auth.jwt.filter.LoginFilter;

--- a/src/main/java/org/spring/dojooo/auth/mail/controller/EmailController.java
+++ b/src/main/java/org/spring/dojooo/auth/mail/controller/EmailController.java
@@ -3,7 +3,7 @@ package org.spring.dojooo.auth.mail.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.mail.dto.EmailMessage;
 import org.spring.dojooo.auth.mail.dto.EmailPost;
 import org.spring.dojooo.auth.mail.dto.EmailResponse;
@@ -11,11 +11,8 @@ import org.spring.dojooo.auth.mail.dto.EmailVerifyRequest;
 import org.spring.dojooo.auth.mail.service.EmailService;
 import org.spring.dojooo.global.ErrorCode;
 import org.spring.dojooo.global.exception.ApiException;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.Duration;
 
 
 @RestController

--- a/src/main/java/org/spring/dojooo/global/ErrorCode.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorCode.java
@@ -32,8 +32,16 @@ public enum ErrorCode {
     TOKEN_EXPIRED("토큰이 만료되었습니다.", 401),
     UNSUPPORTED_TOKEN("지원하지 않는 토큰입니다",400),
 
+    //S3 Exception
+    EMPTY_FILE_EXCEPTION("이미지 파일이 비어있습니다",400),
+    IO_EXCEPTION_ON_IMAGE_UPLOAD("이미지 업로드 중 입출력 오류가 발생하였습니다",500),
+    NO_FILE_EXTENTION("파일 확장자가 존재하지않습니다",400),
+    PUT_OBJECT_EXCEPTION("S3에 파일 업로드 중 오류가 발생했습니다", 500),
+    IO_EXCEPTION_ON_IMAGE_DELETE("이미지 삭제 중 입출력 오류가 발생했습니다", 500),
+
     //임시저장
     UPDATE_TIMEOUT("회원 정보 수정 유효 시간이 초과되었습니다",500);
+
 
 
     private final String message;

--- a/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.auth.jwt.exception.InvalidTokenException;
 import org.spring.dojooo.global.exception.ApiException;
 import org.spring.dojooo.global.exception.NotFoundException;
+import org.spring.dojooo.global.exception.S3Exception;
 import org.spring.dojooo.main.users.exception.DuplicateUserException;
 import org.spring.dojooo.main.users.exception.NotFoundUserException;
 import org.springframework.http.HttpStatus;
@@ -60,6 +61,12 @@ public class GlobalExceptionHandler {
         log.error("handleInvalidTokenException", exception);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TOKEN);
         return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+    @ExceptionHandler(S3Exception.class)
+    public ResponseEntity<ErrorResponse> handleS3Exception(S3Exception exception) {
+        log.error("handleS3Exception", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(exception.getErrorCode());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/java/org/spring/dojooo/global/Redis/RedisConfig.java
+++ b/src/main/java/org/spring/dojooo/global/Redis/RedisConfig.java
@@ -1,4 +1,4 @@
-package org.spring.dojooo.auth.Redis;
+package org.spring.dojooo.global.Redis;
 
 import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/spring/dojooo/global/Redis/RedisUtil.java
+++ b/src/main/java/org/spring/dojooo/global/Redis/RedisUtil.java
@@ -1,4 +1,4 @@
-package org.spring.dojooo.auth.Redis;
+package org.spring.dojooo.global.Redis;
 
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/main/java/org/spring/dojooo/global/S3/S3Config.java
+++ b/src/main/java/org/spring/dojooo/global/S3/S3Config.java
@@ -1,0 +1,35 @@
+package org.spring.dojooo.global.S3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region).build();
+    }
+
+}

--- a/src/main/java/org/spring/dojooo/global/S3/S3FileService.java
+++ b/src/main/java/org/spring/dojooo/global/S3/S3FileService.java
@@ -1,0 +1,118 @@
+package org.spring.dojooo.global.S3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.S3Exception;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3FileService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${S3_BUCKET_NAME}")
+    private String bucketName;
+
+    // 확장자별 Content-Type 매핑
+    private static final Map<String, String> contentTypeMap = Map.of(
+            "jpg", "image/jpeg",
+            "jpeg", "image/jpeg",
+            "png", "image/png",
+            "pdf", "application/pdf",
+            "doc", "application/msword",
+            "txt", "text/plain"
+    );
+
+    public String upload(MultipartFile file,String dirName) {
+        if (file.isEmpty() || Objects.isNull(file.getOriginalFilename())) { //빈파일명 이거나 파일명이 null이면 예외 발생
+            throw new S3Exception(ErrorCode.EMPTY_FILE_EXCEPTION);
+        }
+        return this.uploadFile(file,dirName);
+    }
+
+    public String uploadFile(MultipartFile file, String dirName) {
+        this.validateFileExtension(file.getOriginalFilename());
+        try { //업로드전에 파일 확장자 유효성 검사
+            return this.uploadToS3(file, dirName);
+        } catch (IOException e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
+        }
+    }
+
+    private void validateFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf('.');
+        if (lastDotIndex == -1) { //-1 확장자 없음
+            throw new S3Exception(ErrorCode.NO_FILE_EXTENTION);
+        }
+
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        if (!contentTypeMap.containsKey(extension)) { //허용된 확장자 리스트에 포함되어 있는지 검증.
+            throw new S3Exception(ErrorCode.NO_FILE_EXTENTION); //확장자는 있지만 허용된 확장자가 아님.
+        }
+    }
+
+    private String uploadToS3(MultipartFile file, String dirName) throws IOException {
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename.substring(originalFilename.lastIndexOf('.') + 1).toLowerCase(); //확장자 추출 , 소문자로 변환
+        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + "_" + originalFilename; //UUID를 앞에 붙여 S3에 저장할 새 파일 이름 생성
+        String key = dirName + "/" + s3FileName;
+
+        byte[] bytes = IOUtils.toByteArray(file.getInputStream());
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(contentTypeMap.getOrDefault(extension, "application/octet-stream"));
+        metadata.setContentLength(bytes.length);
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+        try {
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, byteArrayInputStream, metadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead);
+            amazonS3.putObject(putObjectRequest); //파일을 S3에 업로드 - 공개 접근 허용
+        } catch (Exception e) {
+            throw new S3Exception(ErrorCode.PUT_OBJECT_EXCEPTION);
+        } finally {
+            byteArrayInputStream.close();
+        }
+
+        return amazonS3.getUrl(bucketName, key).toString();
+    }
+    //프로필 이미지 삭제
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // Remove leading '/'
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
+        }
+    }
+}

--- a/src/main/java/org/spring/dojooo/global/exception/S3Exception.java
+++ b/src/main/java/org/spring/dojooo/global/exception/S3Exception.java
@@ -1,0 +1,9 @@
+package org.spring.dojooo.global.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+
+public class S3Exception extends BusinessException {
+    public S3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserController.java
@@ -3,7 +3,7 @@ package org.spring.dojooo.main.users.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
 import org.spring.dojooo.global.response.ApiResponse;
 

--- a/src/main/java/org/spring/dojooo/main/users/service/UserService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/UserService.java
@@ -2,7 +2,7 @@ package org.spring.dojooo.main.users.service;
 
 
 import lombok.RequiredArgsConstructor;
-import org.spring.dojooo.auth.Redis.RedisUtil;
+import org.spring.dojooo.global.Redis.RedisUtil;
 import org.spring.dojooo.auth.jwt.security.CustomUserDetailsService;
 import org.spring.dojooo.global.ErrorCode;
 import org.spring.dojooo.global.exception.ApiException;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,4 +28,13 @@ spring.data.redis.host=127.0.0.1
 spring.data.redis.port=6379
 #Security
 spring.jwt.secret=${spring.jwt.secret}
-
+#AWS
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY_ID}
+cloud.aws.credentials.secretKey=${AWS_SECRET_ACCESS_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
+cloud.aws.s3.bucket=${S3_BUCKET_NAME}
+#image
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
### Amazon S3 기반 프로필 사진 등록기능 구현
#### S3 환경설정
- `S3FileService` 컴포넌트를 통해 파일 업로드 / 삭제 기능 구현
- 파일 명 중복 방지를 위해 UUID 적용
- 파일 확장자별 Content-Type 매핑 설정
- 업로드 시, PublicRead 권한 부여 및 URL 반환
- URL을 통한 S3 파일 삭제 기능 구현
```java
public void deleteImageFromS3(String imageAddress) {
    String key = getKeyFromImageAddress(imageAddress);
    try {
        // 전달받은 S3 객체 키를 이용해 S3에서 이미지 삭제
        amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
    } catch (Exception e) {
        throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
    }
}

private String getKeyFromImageAddress(String imageAddress) {
    try {
        // 이미지의 전체 URL에서 S3 객체 키 부분을 추출
        URL url = new URL(imageAddress);
        
        // URL 경로(path) 부분을 UTF-8로 디코딩 (예: 공백 → %20 → 공백으로 복원)
        String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
        
        // URL 경로는 '/'로 시작하므로 앞의 '/'를 제거하여 실제 S3 키로 변환
        return decodingKey.substring(1);
    } catch (MalformedURLException | UnsupportedEncodingException e) {
        throw new S3Exception(ErrorCode.IO_EXCEPTION_ON_IMAGE_DELETE);
    }
}
```
- 지원 확장자 : jpg, jpeg, png, pdf, doc, txt
- S3에 프로필 사진 외에도 게시글(메모장)에도 파일을 업로드할수있도록 기능을 구현해나갈 예정이기에, 이미지 파일외에도 다른 파일도 설정.

#### 프로필 사진 등록 기능 구현
- 이메일로 사용자를 조회한 뒤, 기존에 등록된 프로필 이미지가 있을 경우 삭제 후 새 이미지 업로드 진행
- `s3Uploader.upload(file, "profile") `메서드를 통해 S3의 /profile 디렉터리에 프로필 이미지 업로드
- 업로드된 이미지 URL을 사용자 ID에 연관된 Image 테이블에 저장
- Postman을 통해 Form-Data 방식으로 이미지 업로드 테스트
![PostMan](https://github.com/user-attachments/assets/8795d646-5e33-4d2c-bc37-2cabda2c7f1d)
- 업로드 성공 시, 201 Created 상태 코드와 함께 메시지 반환
- 실제 S3 버킷 내 업로드 결과 예시
![S3](https://github.com/user-attachments/assets/20a42882-80d5-4c45-bcae-e6e79340b321)