### PR TITLE
[Feat] 프로필 초기화 기능 및 유저 관심사 태그 프로필 표시 기능 구현

### DIFF
--- a/src/main/java/org/spring/dojooo/global/ErrorCode.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NO_FILE_EXTENTION("파일 확장자가 존재하지않습니다",400),
     PUT_OBJECT_EXCEPTION("S3에 파일 업로드 중 오류가 발생했습니다", 500),
     IO_EXCEPTION_ON_IMAGE_DELETE("이미지 삭제 중 입출력 오류가 발생했습니다", 500),
+    NOT_USER_EQUALS_CURRENTUSER("본인 프로필만 수정 후 저장할 수 있습니다",403),
 
     //프로필
     WRONG_USER_EDIT("본인의 프로필만 수정할 수 있습니다.",403),

--- a/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.spring.dojooo.global.exception.NotFoundException;
 import org.spring.dojooo.global.exception.S3Exception;
 import org.spring.dojooo.main.users.exception.DuplicateUserException;
 import org.spring.dojooo.main.users.exception.NotFoundUserException;
+import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
 import org.spring.dojooo.main.users.exception.WrongUserEditException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -73,6 +74,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleWrongUserEditException(WrongUserEditException exception) {
         log.error("handleWrongUserEditException", exception);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.WRONG_USER_EDIT);
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
+    }
+    @ExceptionHandler(NotUserEqualsCurrentUserException.class)
+    public ResponseEntity<ErrorResponse> handleNotUserEqualsCurrentUserException(NotUserEqualsCurrentUserException exception) {
+        log.error("handleNotUserEqualsCurrentUserException", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
 

--- a/src/main/java/org/spring/dojooo/main/contents/domain/Memo/Memo.java
+++ b/src/main/java/org/spring/dojooo/main/contents/domain/Memo/Memo.java
@@ -1,0 +1,36 @@
+package org.spring.dojooo.main.contents.domain.Memo;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.spring.dojooo.main.contents.model.MemoCategory;
+import org.spring.dojooo.main.users.domain.User;
+
+@Getter
+@Entity
+@Table(name="memo") //UserId 로 각 User의 메모를 구분
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class Memo {
+    @Id
+    @Column(name="memo_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @Column
+    private MemoCategory category;
+
+    @Column
+    private String content;
+
+
+
+
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/contents/domain/Memo/Tag.java
+++ b/src/main/java/org/spring/dojooo/main/contents/domain/Memo/Tag.java
@@ -1,0 +1,24 @@
+package org.spring.dojooo.main.contents.domain.Memo;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+//사용자가 추가하고 삭제할 수있도록 설계 하기위해
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Embeddable
+public class Tag {
+
+    @Column(name="tag_name",nullable = false,length=45)
+    private String tagName;
+
+    @Column(name="show_on_profile")
+    private boolean showOnProfile; //프로필에 표시할 테그
+
+    public Tag withShowOnProfile(boolean showOnProfile) {
+        return new Tag(this.tagName, showOnProfile);
+    }
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/contents/model/MemoCategory.java
+++ b/src/main/java/org/spring/dojooo/main/contents/model/MemoCategory.java
@@ -1,0 +1,18 @@
+package org.spring.dojooo.main.contents.model;
+
+import lombok.*;
+
+//고정된카테고리
+@AllArgsConstructor
+@Getter
+public enum MemoCategory {
+    DIARY("일기"),
+    MEMO("메모"),
+    TODO("할일"),
+    WORK("업무기록"),
+    STUDY("공부기록"),
+    DRAW("그림");
+
+    private final String displayName;
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserProfileController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserProfileController.java
@@ -54,4 +54,11 @@ public class UserProfileController {
         ProfileDetails profileDetails = userProfileService.getProfile(userId, authentication);
         return ResponseEntity.ok(ApiResponse.ok(profileDetails));
     }
+    @Operation(summary = "유저 페이지 프로필 초기화", description = "프로필이미지는 기본이미지로 설정되고, 자기소개는 초기화됩니다")
+    @PostMapping("/reset/{userId}")
+    public ResponseEntity<ApiResponse<ProfileDetails>> resetProfile(@PathVariable Long userId, Authentication authentication){
+        userProfileService.resetrofile(userId, authentication);
+        ProfileDetails profileDetails = userProfileService.getProfile(userId, authentication);
+        return ResponseEntity.ok(ApiResponse.ok(profileDetails));
+    }
 }

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserProfileController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserProfileController.java
@@ -57,7 +57,7 @@ public class UserProfileController {
     @Operation(summary = "유저 페이지 프로필 초기화", description = "프로필이미지는 기본이미지로 설정되고, 자기소개는 초기화됩니다")
     @PostMapping("/reset/{userId}")
     public ResponseEntity<ApiResponse<ProfileDetails>> resetProfile(@PathVariable Long userId, Authentication authentication){
-        userProfileService.resetrofile(userId, authentication);
+        userProfileService.resetProfile(userId, authentication);
         ProfileDetails profileDetails = userProfileService.getProfile(userId, authentication);
         return ResponseEntity.ok(ApiResponse.ok(profileDetails));
     }

--- a/src/main/java/org/spring/dojooo/main/users/domain/User.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/User.java
@@ -25,12 +25,9 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank(message = "닉네임을 입력해주세요")
     @Column(nullable = false, unique = true, length = 45)
     private String nickname;
 
-    @NotBlank(message ="이메일을 입력해주세요")
-    @Email(message = "이메일을 올바르게 입력해주세요") //이메일 형식 검증
     @Column(nullable = false, unique = true, length = 50)
     private String email;
 

--- a/src/main/java/org/spring/dojooo/main/users/domain/User.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/User.java
@@ -1,16 +1,16 @@
 package org.spring.dojooo.main.users.domain;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.*;
 import lombok.*;
 import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.main.contents.domain.Memo.Tag;
 import org.spring.dojooo.main.users.dto.UserUpdateRequest;
 import org.spring.dojooo.main.users.exception.IllegalArgumentException;
 import org.spring.dojooo.main.users.model.Role;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 
-import java.util.Arrays;
+import java.util.*;
 
 @Getter
 @Entity
@@ -47,6 +47,11 @@ public class User {
 
     @Embedded
     private Profile profile;
+
+    //관심사 테그(프로필에서표사) - 유저는 여러개의 테그를 가질수있다.
+    @ElementCollection
+    @CollectionTable(name="user_tags", joinColumns = @JoinColumn(name="user_id"))
+    private List<Tag> tags = new ArrayList<>();
 
     //프로필 이미지 등록하지않아도, 기본이미지가 보이게, 프로필 이미지 새로등록하면 기본이미지에서 바뀌는 로직으로
     private static final String DEFAULT_PROFILE_IMAGE = "https://dojooo.s3.ap-northeast-2.amazonaws.com/profile/80aefad7-3_기본프로필.jpg";
@@ -104,7 +109,10 @@ public class User {
     public void updateProfile(Profile profile) {
         this.profile = profile;
     }
-
-
+    //Setter 대신 - tag
+    public void replaceTags(List<Tag> updatedTags) {
+        this.tags.clear();
+        this.tags.addAll(updatedTags);
+    }
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
@@ -2,9 +2,11 @@ package org.spring.dojooo.main.users.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.spring.dojooo.main.contents.domain.Memo.Tag;
 import org.spring.dojooo.main.users.domain.Profile;
 import org.spring.dojooo.main.users.domain.User;
 
+import java.util.List;
 import java.util.Optional;
 
 @Getter
@@ -16,8 +18,8 @@ public class ProfileDetails {
     private String introduction;
     private Boolean isMine;
     private static final String DEFAULT_PROFILE_IMAGE = "https://dojooo.s3.ap-northeast-2.amazonaws.com/profile/80aefad7-3_%E1%84%80%E1%85%B5%E1%84%87%E1%85%A9%E1%86%AB%E1%84%91%E1%85%B3%E1%84%85%E1%85%A9%E1%84%91%E1%85%B5%E1%86%AF.jpg";
+    private List<String> tags;
 
-    // ProfileDetails.java
     public static ProfileDetails of(User user, boolean isOwner) {
         Profile profile = user.getProfile();
         String profileImage = (profile != null && profile.getProfileImage() != null && !profile.getProfileImage().isBlank())
@@ -28,12 +30,20 @@ public class ProfileDetails {
                 .map(Profile::getIntroduction)
                 .orElse("");
 
+        List<String> tagNames = Optional.ofNullable(user.getTags())
+                .orElse(List.of()) //null이면 빈 리스트 처리
+                .stream()
+                .filter(Tag::isShowOnProfile) //프로필에 보여질 테그만
+                .map(Tag::getTagName) //Tag 객체가 아니라, Tag의 이름만 추출
+                .toList();
+
         return ProfileDetails.builder()
                 .id(user.getId())
                 .profileImage(profileImage)
                 .nickname(user.getNickname())
                 .introduction(introduction)
                 .isMine(isOwner)
+                .tags(tagNames)
                 .build();
     }
     }

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileUpdateRequest.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileUpdateRequest.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,5 +18,7 @@ public class ProfileUpdateRequest {
     private String introduction;
 
     private String profileImageUrl;
+
+    private List<String> tagNames;
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/dto/UserSignUpRequest.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/UserSignUpRequest.java
@@ -1,13 +1,22 @@
 package org.spring.dojooo.main.users.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.Getter;
 import org.spring.dojooo.main.users.domain.User;
 
 @Getter
 public class UserSignUpRequest {
+
+    @NotBlank(message = "닉네임을 입력헤주세요")
     private String nickname;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
     private String password;
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    @Email(message ="이메일을 올바르게 입력해주세요")
     private String email;
 
     public User toEntity(){

--- a/src/main/java/org/spring/dojooo/main/users/exception/NotUserEqualsCurrentUserException.java
+++ b/src/main/java/org/spring/dojooo/main/users/exception/NotUserEqualsCurrentUserException.java
@@ -1,0 +1,10 @@
+package org.spring.dojooo.main.users.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.BusinessException;
+
+public class NotUserEqualsCurrentUserException extends BusinessException {
+    public NotUserEqualsCurrentUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
### 프로필 초기화 기능 구현
- 사용자가 프로필 초기화를 요청하면, 자기소개는 비워지고 프로필 이미지는 기본 이미지로 변경되도록 구현
- 기존에 사용자가 프로필 사진을 업로드한 경우, 해당 이미지는 S3에서 삭제된 후 기본 이미지로 대체됨

### 관심사 태그 프로필 표시 기능 구현
- 사용자의 메모 태그 중, 프로필에 표시할 태그만 필터링하여 사용자 프로필에 노출되도록 구현
- 태그 선택은 프로필 최초 저장 시에는 불가능하고, 수정 시에만 가능
- 최대 5개의 태그만 선택 가능하며, 선택하지 않아도 되므로 null 허용 (Optional.ofNullable)	
- 표시 대상 태그는 다음과 같이 필터링 및 추출:
```
   List<String> tagNames = Optional.ofNullable(user.getTags())
                .orElse(List.of()) //null이면 빈 리스트 처리
                .stream()
                .filter(Tag::isShowOnProfile) //프로필에 보여질 테그만
                .map(Tag::getTagName) //Tag 객체가 아니라, Tag의 이름만 추출
                .toList();
```
- 전체 태그는 user.getTags()를 통해 가져오며, 그 중 isShowOnProfile == true인 태그만 필터링