### PR TITLE
[Feat]사용자 태그 등록 및 수정 기능 구현

### DIFF
--- a/src/main/java/org/spring/dojooo/global/ErrorCode.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorCode.java
@@ -44,7 +44,11 @@ public enum ErrorCode {
     WRONG_USER_EDIT("본인의 프로필만 수정할 수 있습니다.",403),
 
     //메모
-    DUPLICAT_MEMO_HEADER("이미 사용중인 제목입니다. 다른 제목으로 작성해주세요",400);
+    DUPLICATE_MEMO_HEADER("이미 사용중인 제목입니다. 다른 제목으로 작성해주세요",400),
+
+    //테그 관련
+    DUPLICATE_TAG_EXCEPTION("이미 등록된 테그입니다",400),
+    NOTFOUND_TAG_EXCEPTION("테그를 찾을 수 없습니다",404);
 
 
 

--- a/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
@@ -3,17 +3,18 @@ package org.spring.dojooo.global;
 import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.auth.jwt.exception.InvalidTokenException;
 import org.spring.dojooo.global.exception.ApiException;
+import org.spring.dojooo.global.exception.DuplicateException;
 import org.spring.dojooo.global.exception.NotFoundException;
 import org.spring.dojooo.global.exception.S3Exception;
-import org.spring.dojooo.main.users.exception.DuplicateUserException;
-import org.spring.dojooo.main.users.exception.NotFoundUserException;
-import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
-import org.spring.dojooo.main.users.exception.WrongUserEditException;
+import org.spring.dojooo.main.users.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.lang.IllegalArgumentException;
+
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -39,7 +40,7 @@ public class GlobalExceptionHandler {
                 ErrorCode.INVALID_INPUT, exception.getBindingResult());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
-    @ExceptionHandler(NotFoundUserException.class)
+    @ExceptionHandler({NotFoundUserException.class, NotFoundTagException.class})
     public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException exception) {
         log.error("handleNotFoundException", exception);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND_RESOURCE);
@@ -52,8 +53,8 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(DuplicateUserException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateUserException(DuplicateUserException exception) {
+    @ExceptionHandler({DuplicateUserException.class, DuplicateTagException.class})
+    public ResponseEntity<ErrorResponse> handleDuplicateException(DuplicateException exception) {
         log.error("handleDuplicateUserException", exception);
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.CONFLICT_ERROR);
         return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);

--- a/src/main/java/org/spring/dojooo/global/domain/Tag.java
+++ b/src/main/java/org/spring/dojooo/global/domain/Tag.java
@@ -1,19 +1,35 @@
 package org.spring.dojooo.global.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.spring.dojooo.main.users.domain.User;
 
 //사용자가 추가하고 삭제할 수있도록 설계 하기위해
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
     private User user;
 
     @Column(nullable = false,length=10)
     private String tagName;
 
+    public Tag(String tagName, User user) {
+        this.tagName = tagName;
+        this.user = user;
+    }
+
+    public void updateTagName(String tagName) {
+        this.tagName = tagName;
+    }
 }
+

--- a/src/main/java/org/spring/dojooo/global/exception/DuplicateException.java
+++ b/src/main/java/org/spring/dojooo/global/exception/DuplicateException.java
@@ -1,0 +1,9 @@
+package org.spring.dojooo.global.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+
+public class DuplicateException extends BusinessException {
+    public DuplicateException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/spring/dojooo/global/repository/TagRepository.java
+++ b/src/main/java/org/spring/dojooo/global/repository/TagRepository.java
@@ -1,0 +1,15 @@
+package org.spring.dojooo.global.repository;
+
+import org.spring.dojooo.global.domain.Tag;
+import org.spring.dojooo.main.users.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByTagNameAndUser(String tagName, User user);
+
+}

--- a/src/main/java/org/spring/dojooo/main/contents/domain/CheckList.java
+++ b/src/main/java/org/spring/dojooo/main/contents/domain/CheckList.java
@@ -18,7 +18,7 @@ public class CheckList {
     @Column(name="checklist_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="user_id")
     private User user;
 

--- a/src/main/java/org/spring/dojooo/main/contents/domain/ChecklistTag.java
+++ b/src/main/java/org/spring/dojooo/main/contents/domain/ChecklistTag.java
@@ -12,11 +12,11 @@ public class ChecklistTag {
     @Column(name ="checklist_tag_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="tag_id")
     private Tag tag;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="checklist_id")
     private CheckList checklist;
 

--- a/src/main/java/org/spring/dojooo/main/contents/domain/TechLog.java
+++ b/src/main/java/org/spring/dojooo/main/contents/domain/TechLog.java
@@ -20,7 +20,7 @@ public class TechLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id")
     private User user; //사용자정보
 

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.spring.dojooo.global.response.ApiResponse;
 import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.dto.ProfileTagRequest;
+import org.spring.dojooo.main.users.dto.ProfileTagUpdateRequest;
 import org.spring.dojooo.main.users.dto.TagDetails;
 import org.spring.dojooo.main.users.dto.TagDetailsList;
 import org.spring.dojooo.main.users.service.ProfileTagService;
@@ -39,14 +40,14 @@ public class UserProfileTagController {
         return ResponseEntity.ok(ApiResponse.ok(response));
 
     }
-//    @Operation(summary = "설정한 테그 수정", description = "프로필에 등록하기위해 설정한 테그를 수정합니다")
-//    @PatchMapping("/edit/{userId}")
-//    public ResponseEntity<ApiResponse<TagDetails>>editTag(@PathVariable Long userId, @RequestBody ProfileTagRequest profileTagRequest, Authentication authentication) {
-//        ProfileTag updateTag = profileTagService.updateTag(userId, profileTagRequest, authentication);
-//        TagDetails response = TagDetails.from(updateTag.getUser(), updateTag);
-//        return ResponseEntity.ok(ApiResponse.ok(response));
-//
-//
+    @Operation(summary = "설정한 테그 수정", description = "프로필에 등록하기위해 설정한 테그를 수정합니다")
+    @PatchMapping("/edit/{userId}")
+    public ResponseEntity<ApiResponse<TagDetails>>editTag(@PathVariable Long userId, @RequestBody ProfileTagUpdateRequest profileTagUpdateRequest, Authentication authentication) {
+        ProfileTag updateTag = profileTagService.updateTag(userId, profileTagUpdateRequest, authentication);
+        TagDetails response = TagDetails.from(updateTag.getUser(), updateTag);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+
+    }
 
     @Operation(summary = "테그 삭제",description = "프로필에 등록하기위해 설정한 테그를 삭제합니다")
     @DeleteMapping("/delete/{userId}")

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
@@ -3,6 +3,7 @@ package org.spring.dojooo.main.users.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.spring.dojooo.global.domain.Tag;
 import org.spring.dojooo.global.response.ApiResponse;
 import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.dto.ProfileTagRequest;
@@ -49,9 +50,14 @@ public class UserProfileTagController {
 
     }
 
-    @Operation(summary = "테그 삭제",description = "프로필에 등록하기위해 설정한 테그를 삭제합니다")
+    @Operation(summary = "태그 삭제", description = "프로필에 등록하기 위해 설정한 태그를 삭제합니다")
     @DeleteMapping("/delete/{userId}")
-    public ResponseEntity<ApiResponse> deleteTag(@PathVariable Long userId, @RequestBody ProfileTagRequest profileTagRequest,Authentication authentication) {
-        return ResponseEntity.ok(ApiResponse.of(200,"테그 삭제가 완료되었습니다",profileTagService.deleteTag(userId, profileTagRequest, authentication)));
+    public ResponseEntity<ApiResponse> deleteTag(
+            @PathVariable Long userId,
+            @RequestBody ProfileTagRequest profileTagRequest,
+            Authentication authentication
+    ) {
+        String deletedTagName = profileTagService.deleteTag(userId, profileTagRequest, authentication);
+        return ResponseEntity.ok(ApiResponse.of(200, "태그 삭제가 완료되었습니다", deletedTagName));
     }
 }

--- a/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
+++ b/src/main/java/org/spring/dojooo/main/users/controller/UserProfileTagController.java
@@ -1,0 +1,56 @@
+package org.spring.dojooo.main.users.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.spring.dojooo.global.response.ApiResponse;
+import org.spring.dojooo.main.users.domain.ProfileTag;
+import org.spring.dojooo.main.users.dto.ProfileTagRequest;
+import org.spring.dojooo.main.users.dto.TagDetails;
+import org.spring.dojooo.main.users.dto.TagDetailsList;
+import org.spring.dojooo.main.users.service.ProfileTagService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/profile/tags")
+public class UserProfileTagController {
+    private final ProfileTagService profileTagService;
+
+
+    @Operation(
+            summary = "사용자가 생성한 전체 태그 조회",
+            description = "사용자가 생성한 기술 스택 태그를 조회합니다. 이 태그들은 프로필에 등록하여 기술을 소개할 수 있습니다."
+    )
+    @GetMapping("{userId}")
+    public ResponseEntity<ApiResponse<TagDetailsList>> getProfileTags(@PathVariable Long userId, Authentication authentication) {
+        TagDetailsList tagDetailsList = profileTagService.getProfileTag(userId, authentication);
+        return ResponseEntity.ok(ApiResponse.ok(tagDetailsList));
+    }
+
+    @Operation(summary = "프로필에 등록할 테그 설정", description = "프로필에 스택과 같은 기술을 소개할수있는 태그를 생성합니다")
+    @PostMapping("/save/{userId}")
+    public ResponseEntity<ApiResponse<TagDetails>> saveTag(@PathVariable Long userId, @RequestBody ProfileTagRequest profileTagUpdateRequest ,Authentication authentication) {
+        ProfileTag savedTag = profileTagService.saveTag(userId,profileTagUpdateRequest, authentication);
+        TagDetails response = TagDetails.from(savedTag.getUser(), savedTag);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+
+    }
+//    @Operation(summary = "설정한 테그 수정", description = "프로필에 등록하기위해 설정한 테그를 수정합니다")
+//    @PatchMapping("/edit/{userId}")
+//    public ResponseEntity<ApiResponse<TagDetails>>editTag(@PathVariable Long userId, @RequestBody ProfileTagRequest profileTagRequest, Authentication authentication) {
+//        ProfileTag updateTag = profileTagService.updateTag(userId, profileTagRequest, authentication);
+//        TagDetails response = TagDetails.from(updateTag.getUser(), updateTag);
+//        return ResponseEntity.ok(ApiResponse.ok(response));
+//
+//
+
+    @Operation(summary = "테그 삭제",description = "프로필에 등록하기위해 설정한 테그를 삭제합니다")
+    @DeleteMapping("/delete/{userId}")
+    public ResponseEntity<ApiResponse> deleteTag(@PathVariable Long userId, @RequestBody ProfileTagRequest profileTagRequest,Authentication authentication) {
+        return ResponseEntity.ok(ApiResponse.of(200,"테그 삭제가 완료되었습니다",profileTagService.deleteTag(userId, profileTagRequest, authentication)));
+    }
+}

--- a/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
@@ -11,7 +11,7 @@ import org.spring.dojooo.global.domain.Tag;
 public class ProfileTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "proffile_tag_id")
+    @Column(name = "profile_tag_id")
     private Long id;
 
     @Column

--- a/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
@@ -1,0 +1,65 @@
+package org.spring.dojooo.main.users.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.spring.dojooo.global.domain.Tag;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class ProfileTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "proffile_tag_id")
+    private Long id;
+
+    @Column
+    private String colorCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="tag_id")
+    private Tag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id")
+    private User user;
+
+    @Column(columnDefinition = "TINYINT default 0",name="is_deleted")
+    private boolean isDeleted;
+
+    @Column(columnDefinition = "TINYINT default 0",name="show_on_profile")
+    private boolean showOnProfile;
+
+    @Builder
+    public ProfileTag(String colorCode, Tag tag, User user, Boolean isDeleted, Boolean showOnProfile) {
+        this.colorCode = colorCode;
+        this.tag = tag;
+        this.user = user;
+        this.isDeleted = isDeleted != null ? isDeleted : false;
+        this.showOnProfile = showOnProfile != null ? showOnProfile : false;
+    }
+    private void updateTagName(String newTagName) {
+        if(newTagName != null && !newTagName.isEmpty()) {
+            this.tag.updateTagName(newTagName);
+        }
+    }
+
+
+    public void updateColorCode(String colorCode){
+        if(colorCode != null && !colorCode.isBlank()){
+            this.colorCode = colorCode;
+        }
+    }
+    public void deleteTag(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+    public void settingShowOnProfile(boolean showOnProfile){
+        this.showOnProfile = showOnProfile;
+    }
+
+
+
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/ProfileTag.java
@@ -39,20 +39,11 @@ public class ProfileTag {
         this.isDeleted = isDeleted != null ? isDeleted : false;
         this.showOnProfile = showOnProfile != null ? showOnProfile : false;
     }
-    private void updateTagName(String newTagName) {
-        if(newTagName != null && !newTagName.isEmpty()) {
-            this.tag.updateTagName(newTagName);
-        }
-    }
-
 
     public void updateColorCode(String colorCode){
         if(colorCode != null && !colorCode.isBlank()){
             this.colorCode = colorCode;
         }
-    }
-    public void deleteTag(boolean isDeleted) {
-        this.isDeleted = isDeleted;
     }
     public void settingShowOnProfile(boolean showOnProfile){
         this.showOnProfile = showOnProfile;

--- a/src/main/java/org/spring/dojooo/main/users/domain/User.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/User.java
@@ -47,10 +47,8 @@ public class User {
     @Embedded
     private Profile profile;
 
-    //관심사 테그(프로필에서표사) - 유저는 여러개의 테그를 가질수있다.
-//    @ElementCollection
-//    @CollectionTable(name="user_tags", joinColumns = @JoinColumn(name="user_id"))
-//    //rivate List<Tag> tags = new ArrayList<>();
+    @OneToMany(cascade = CascadeType.ALL,mappedBy = "user")
+    private List<ProfileTag> profileTags = new ArrayList<>();
 
     //프로필 이미지 등록하지않아도, 기본이미지가 보이게, 프로필 이미지 새로등록하면 기본이미지에서 바뀌는 로직으로
     private static final String DEFAULT_PROFILE_IMAGE = "https://dojooo.s3.ap-northeast-2.amazonaws.com/profile/80aefad7-3_기본프로필.jpg";
@@ -58,12 +56,12 @@ public class User {
 
 
     @Builder
-    public User(String nickname, String email, String password,Profile profile) {
+    public User(String nickname, String email,Boolean isDeleted, String password,Profile profile) {
         this.nickname = nickname;
         this.email = email;
         this.password = password;
         this.role = Role.USER;
-        this.isDeleted = false;
+        this.isDeleted = isDeleted != null ? isDeleted : false;
         this.profile = new Profile(DEFAULT_PROFILE_IMAGE,null); //profileimage = null, introduction = null
 
     }
@@ -108,10 +106,6 @@ public class User {
     public void updateProfile(Profile profile) {
         this.profile = profile;
     }
-//    //Setter 대신 - tag
-//    public void replaceTags(List<Tag> updatedTags) {
-//        this.tags.clear();
-//        this.tags.addAll(updatedTags);
-//    }
+
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/dto/HasTagName.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/HasTagName.java
@@ -1,0 +1,5 @@
+package org.spring.dojooo.main.users.dto;
+
+public interface HasTagName {
+    String getTagName();
+}

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
@@ -1,7 +1,6 @@
 package org.spring.dojooo.main.users.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 import org.spring.dojooo.main.users.domain.Profile;
 import org.spring.dojooo.main.users.domain.User;
 

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagRequest.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagRequest.java
@@ -5,12 +5,17 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-public class ProfileTagRequest {
+public class ProfileTagRequest implements HasTagName {
 
     //태그이름
     private String tagName;
 
     //태그 색상 설정
     private String colorcode;
+
+    @Override
+    public String getTagName() {
+        return tagName;
+    }
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagRequest.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagRequest.java
@@ -1,0 +1,16 @@
+package org.spring.dojooo.main.users.dto;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class ProfileTagRequest {
+
+    //태그이름
+    private String tagName;
+
+    //태그 색상 설정
+    private String colorcode;
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagUpdateRequest.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileTagUpdateRequest.java
@@ -1,0 +1,22 @@
+package org.spring.dojooo.main.users.dto;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class ProfileTagUpdateRequest implements HasTagName {
+
+    private String originalTagName;
+    private String newTagName;
+
+    private String originalColorCode;
+    private String newColorCode;
+
+    @Override
+    public String getTagName() {
+        return newTagName != null && !newTagName.isBlank() ? newTagName : originalTagName;
+    }
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/dto/TagDetails.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/TagDetails.java
@@ -1,0 +1,27 @@
+package org.spring.dojooo.main.users.dto;
+
+import lombok.*;
+import org.spring.dojooo.main.users.domain.ProfileTag;
+import org.spring.dojooo.main.users.domain.User;
+//단일 테그
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TagDetails {
+    private Long id;
+    private String tagName;
+    private String colorCode;
+    private boolean isDeleted;
+    private boolean showOnProfile;
+
+    public static TagDetails from(User user, ProfileTag profileTag) {
+        return TagDetails.builder()
+                .id(user.getId())
+                .tagName(profileTag.getTag().getTagName())
+                .colorCode(profileTag.getColorCode())
+                .isDeleted(profileTag.isDeleted())
+                .showOnProfile(profileTag.isShowOnProfile())
+                .build();
+    }
+}

--- a/src/main/java/org/spring/dojooo/main/users/dto/TagDetailsList.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/TagDetailsList.java
@@ -1,0 +1,28 @@
+package org.spring.dojooo.main.users.dto;
+
+import lombok.*;
+import org.spring.dojooo.main.users.domain.ProfileTag;
+import org.spring.dojooo.main.users.domain.User;
+
+import java.util.List;
+//사용자에 등록되어있는 전체 테그를 조회하는 DTO
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TagDetailsList {
+    private Long userId;
+    private List<TagDetails> tags;
+
+    public static TagDetailsList from(User user, List<ProfileTag> profileTags) {
+        List<TagDetails> tagDetailsList = profileTags.stream()
+                .map(profileTag -> TagDetails.from(user, profileTag))
+                .toList();
+        return TagDetailsList.builder()
+                .userId(user.getId())
+                .tags(tagDetailsList).build();
+    }
+
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/exception/DuplicateTagException.java
+++ b/src/main/java/org/spring/dojooo/main/users/exception/DuplicateTagException.java
@@ -1,0 +1,10 @@
+package org.spring.dojooo.main.users.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.BusinessException;
+
+public class DuplicateTagException extends BusinessException {
+  public DuplicateTagException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/org/spring/dojooo/main/users/exception/NotFoundTagException.java
+++ b/src/main/java/org/spring/dojooo/main/users/exception/NotFoundTagException.java
@@ -1,0 +1,10 @@
+package org.spring.dojooo.main.users.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.BusinessException;
+
+public class NotFoundTagException extends BusinessException {
+    public NotFoundTagException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/spring/dojooo/main/users/repository/ProfileTagReposiotry.java
+++ b/src/main/java/org/spring/dojooo/main/users/repository/ProfileTagReposiotry.java
@@ -1,0 +1,16 @@
+package org.spring.dojooo.main.users.repository;
+
+import org.spring.dojooo.main.users.domain.ProfileTag;
+import org.spring.dojooo.main.users.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+public interface ProfileTagReposiotry extends JpaRepository<ProfileTag, Long> {
+    List<ProfileTag> findAllByUser(User user);
+    long countByUser(User user);
+    Optional<ProfileTag> findByUserAndTag_TagNameAndIsDeletedFalse(User user, String tagName); //삭제되지않는 테
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/repository/ProfileTagRepository.java
+++ b/src/main/java/org/spring/dojooo/main/users/repository/ProfileTagRepository.java
@@ -1,16 +1,19 @@
 package org.spring.dojooo.main.users.repository;
 
+import org.spring.dojooo.global.domain.Tag;
 import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
 
 @Repository
-public interface ProfileTagReposiotry extends JpaRepository<ProfileTag, Long> {
+public interface ProfileTagRepository extends JpaRepository<ProfileTag, Long> {
     List<ProfileTag> findAllByUser(User user);
-    long countByUser(User user);
     Optional<ProfileTag> findByUserAndTag_TagNameAndIsDeletedFalse(User user, String tagName); //삭제되지않는 테
 
-}
+    @Query("SELECT CASE WHEN COUNT(pt) > 0 THEN true ELSE false END FROM ProfileTag pt WHERE pt.user.id = :userId AND pt.tag = :tag")
+    boolean existsByUserIdAndTag(@Param("userId") Long userId, @Param("tag") Tag tag);}

--- a/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
@@ -1,0 +1,133 @@
+package org.spring.dojooo.main.users.service;
+
+import lombok.RequiredArgsConstructor;
+import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.domain.Tag;
+import org.spring.dojooo.global.repository.TagRepository;
+import org.spring.dojooo.main.users.domain.ProfileTag;
+import org.spring.dojooo.main.users.domain.User;
+import org.spring.dojooo.main.users.dto.*;
+import org.spring.dojooo.main.users.exception.DuplicateTagException;
+import org.spring.dojooo.main.users.exception.NotFoundTagException;
+import org.spring.dojooo.main.users.exception.NotFoundUserException;
+import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
+import org.spring.dojooo.main.users.repository.ProfileTagReposiotry;
+import org.spring.dojooo.main.users.repository.UserRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileTagService {
+
+    private final TagRepository tagRepository;
+    private final UserRepository userRepository;
+    private final ProfileTagReposiotry profileTagReposiotry;
+
+    //조회
+    @Transactional(readOnly = true)
+    public TagDetailsList getProfileTag(Long userId,Authentication authentication) {
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        List<ProfileTag> userprofileTags = profileTagReposiotry.findAllByUser(user);
+        return TagDetailsList.from(user, userprofileTags);
+    }
+    //테그 저장(처음)
+    @Transactional
+    public ProfileTag saveTag(Long userId, ProfileTagRequest profileTagUpdateRequest, Authentication authentication) {
+        //권한 체크
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+
+        //유저조회
+        User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+
+        //중복확인 (같은 이름의 테그, 같은 유저, 이미 프로필 등록된 경우)
+        duplicateTag(userId,profileTagUpdateRequest, authentication);
+        //테그 10자 제한
+        checkTagLength(profileTagUpdateRequest.getTagName());
+        //이미 있는 테그인지 아니면 생성
+        Tag tag = tagRepository.findByTagNameAndUser(profileTagUpdateRequest.getTagName(), user)
+                    .orElseGet(() -> tagRepository.save(new Tag(profileTagUpdateRequest.getTagName(), user)));
+        ProfileTag profileTag =ProfileTag.builder()
+                 .user(user)
+                 .tag(tag)
+                 .colorCode(profileTagUpdateRequest.getColorcode())
+                 .showOnProfile(false)
+                 .isDeleted(false)
+                 .build();
+        return profileTagReposiotry.save(profileTag);
+    }
+//    //태그 수정
+//    @Transactional
+//    public ProfileTag updateTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
+//        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+//
+//        User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+//
+//
+//
+//        ProfileTag profileTag = profileTagReposiotry
+//                .findByUserAndTag_TagNameAndIsDeletedFalse(user, profileTagRequest.getOriginalTagName())
+//                .orElseThrow(() -> new NotFoundTagException(ErrorCode.NOTFOUND_TAG_EXCEPTION));
+//        checkTagLength(profileTagRequest.getTagName());
+//
+//        profileTag.getTag().updateTagName(profileTagRequest.getTagName());
+//
+//        profileTag.updateColorCode(profileTagRequest.getColorcode());
+//
+//        return profileTag;
+//    }
+
+    //태그 삭제
+    @Transactional
+    public String deleteTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
+        ProfileTag targetDeleteTag = findTargetTag(userId,profileTagRequest,authentication);
+        profileTagReposiotry.delete(targetDeleteTag);
+        return targetDeleteTag.getTag().getTagName();
+    }
+
+    //테그 10자이상 작성시 Exception
+    public void checkTagLength(String tagName) {
+        if(tagName.length()>10){
+            throw new IllegalArgumentException("테그는 10자 이내로 작성가능합니다");
+        }
+    }
+    //테그 리스트중에서 조건에 맞는 테그 하나를 찾는 로직
+    public ProfileTag findTargetTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+
+        return profileTagReposiotry.findByUserAndTag_TagNameAndIsDeletedFalse(user, profileTagRequest.getTagName())
+                .orElseThrow(() -> new NotFoundTagException(ErrorCode.NOTFOUND_TAG_EXCEPTION));
+    }
+    //현재 로그인한 사용자 정보
+    public Long getCurrentUserId(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getId();
+    }
+    //로그인한 사용자와 정보가 같은지 확인
+    public Long userEqualsCurrentUser(Long userId, Long currentUserId) {
+        if(!userId.equals(currentUserId)) {
+            throw new NotUserEqualsCurrentUserException(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
+        }
+        return userId;
+    }
+    //중복 테그인지 아닌지 확인
+    public void duplicateTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+
+        boolean alreadyRegistered = profileTagReposiotry.findAllByUser(user).stream()
+                .anyMatch(pt -> pt.getTag().getTagName().equals(profileTagRequest.getTagName()));
+        if (alreadyRegistered) {
+            throw new DuplicateTagException(ErrorCode.DUPLICATE_TAG_EXCEPTION);
+        }
+    }
+
+
+
+}

--- a/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
@@ -12,7 +12,7 @@ import org.spring.dojooo.main.users.exception.DuplicateTagException;
 import org.spring.dojooo.main.users.exception.NotFoundTagException;
 import org.spring.dojooo.main.users.exception.NotFoundUserException;
 import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
-import org.spring.dojooo.main.users.repository.ProfileTagReposiotry;
+import org.spring.dojooo.main.users.repository.ProfileTagRepository;
 import org.spring.dojooo.main.users.repository.UserRepository;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -26,27 +26,27 @@ public class ProfileTagService {
 
     private final TagRepository tagRepository;
     private final UserRepository userRepository;
-    private final ProfileTagReposiotry profileTagReposiotry;
+    private final ProfileTagRepository profileTagRepository;
 
     //조회
     @Transactional(readOnly = true)
     public TagDetailsList getProfileTag(Long userId,Authentication authentication) {
         userEqualsCurrentUser(getCurrentUserId(authentication), userId);
-        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
-        List<ProfileTag> userprofileTags = profileTagReposiotry.findAllByUser(user);
+        User user = findCurrentUser(userId);
+        List<ProfileTag> userprofileTags = profileTagRepository.findAllByUser(user);
         return TagDetailsList.from(user, userprofileTags);
     }
-    //테그 저장(처음)
+    //태그 저장(처음)
     @Transactional
     public ProfileTag saveTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
         //권한 체크
         userEqualsCurrentUser(getCurrentUserId(authentication), userId);
 
         //유저조회
-        User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        User user = findCurrentUser(userId);
 
         //중복확인 (같은 이름의 테그, 같은 유저, 이미 프로필 등록된 경우)
-        duplicateTag(userId,profileTagRequest, authentication);
+        duplicateTag(user,profileTagRequest);
         //테그 10자 제한
         checkTagLength(profileTagRequest.getTagName());
         //이미 있는 테그인지 아니면 생성
@@ -59,24 +59,24 @@ public class ProfileTagService {
                  .showOnProfile(false)
                  .isDeleted(false)
                  .build();
-        return profileTagReposiotry.save(profileTag);
+        return profileTagRepository.save(profileTag);
     }
     //태그 수정
     @Transactional
     public ProfileTag updateTag(Long userId, ProfileTagUpdateRequest profileTagUpdateRequest, Authentication authentication) {
         userEqualsCurrentUser(getCurrentUserId(authentication), userId);
 
-        User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        User user = findCurrentUser(userId);
 
 
-        ProfileTag profileTag = profileTagReposiotry
+        ProfileTag profileTag = profileTagRepository
                 .findByUserAndTag_TagNameAndIsDeletedFalse(user, profileTagUpdateRequest.getOriginalTagName())
                 .orElseThrow(() -> new NotFoundTagException(ErrorCode.NOTFOUND_TAG_EXCEPTION));
 
         //테그 이름
         if (profileTagUpdateRequest.getNewTagName() != null && !profileTagUpdateRequest.getNewTagName().isBlank()) {
             checkTagLength(profileTagUpdateRequest.getNewTagName());
-            duplicateTag(userId,profileTagUpdateRequest,authentication);
+            duplicateTag(user,profileTagUpdateRequest);
             profileTag.getTag().updateTagName(profileTagUpdateRequest.getNewTagName());
         }
         //색상코드
@@ -90,9 +90,26 @@ public class ProfileTagService {
     //태그 삭제
     @Transactional
     public String deleteTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
-        ProfileTag targetDeleteTag = findTargetTag(userId,profileTagRequest,authentication);
-        profileTagReposiotry.delete(targetDeleteTag);
-        return targetDeleteTag.getTag().getTagName();
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = findCurrentUser(userId);
+        ProfileTag targetDeleteTag = findTargetTag(userId, profileTagRequest, authentication);
+        Tag tag = targetDeleteTag.getTag();
+
+        // 삭제 전에 이름 저장
+        String deletedTagName = tag.getTagName();
+
+        // 프로필 태그 삭제
+        profileTagRepository.delete(targetDeleteTag);
+
+        // 같은 유저의 다른 ProfileTag가 이 태그를 쓰고 있는지 확인
+        boolean isUsedElsewhere = profileTagRepository.existsByUserIdAndTag(userId, tag);
+
+        // 참조 안 되면 태그 삭제
+        if (!isUsedElsewhere) {
+            tagRepository.delete(tag);
+        }
+
+        return deletedTagName;
     }
 
     //테그 10자이상 작성시 Exception
@@ -104,9 +121,8 @@ public class ProfileTagService {
     //테그 리스트중에서 조건에 맞는 테그 하나를 찾는 로직
     public ProfileTag findTargetTag(Long userId, ProfileTagRequest profileTagRequest, Authentication authentication) {
         userEqualsCurrentUser(getCurrentUserId(authentication), userId);
-        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
-
-        return profileTagReposiotry.findByUserAndTag_TagNameAndIsDeletedFalse(user, profileTagRequest.getTagName())
+        User user = findCurrentUser(userId);
+        return profileTagRepository.findByUserAndTag_TagNameAndIsDeletedFalse(user, profileTagRequest.getTagName())
                 .orElseThrow(() -> new NotFoundTagException(ErrorCode.NOTFOUND_TAG_EXCEPTION));
     }
     //현재 로그인한 사용자 정보
@@ -115,25 +131,24 @@ public class ProfileTagService {
         return userDetails.getId();
     }
     //로그인한 사용자와 정보가 같은지 확인
-    public Long userEqualsCurrentUser(Long userId, Long currentUserId) {
+    public void userEqualsCurrentUser(Long userId, Long currentUserId) {
         if(!userId.equals(currentUserId)) {
             throw new NotUserEqualsCurrentUserException(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
         }
-        return userId;
+    }
+    //유저 조회 로직
+    public User findCurrentUser(Long userId) {
+        User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+        return user;
     }
     //중복 테그인지 아닌지 확인
-    public void duplicateTag(Long userId, HasTagName tagRequest, Authentication authentication) {
-        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
-        User user = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
-
-        boolean alreadyRegistered = profileTagReposiotry.findAllByUser(user).stream()
+    public void duplicateTag(User user, HasTagName tagRequest) {
+        boolean alreadyRegistered = profileTagRepository.findAllByUser(user).stream()
                 .anyMatch(pt -> pt.getTag().getTagName().equals(tagRequest.getTagName()));
         if (alreadyRegistered) {
             throw new DuplicateTagException(ErrorCode.DUPLICATE_TAG_EXCEPTION);
         }
     }
-
-
 
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
@@ -58,6 +58,9 @@ public class UserProfileService {
 
         String updatedIntroduction = (getIntroduction != null) ? getIntroduction : (existingProfile != null ? existingProfile.getIntroduction() : null);
 
+
+
+
         Profile updatedprofile = Profile.builder()
                 .profileImage(updatedImageUrl)
                 .introduction(updatedIntroduction)


### PR DESCRIPTION
## 사용자 태그 등록 및 수정 기능 구현 

`/users/profile/tags`

### 구현 내용

### 1. 사용자 프로필 태그 등록 기능
- 사용자는 프로필 수정 기능에서 태그 목록 중 원하는 태그를 선택하여 자신의 기술 스택으로 등록할 수 있음 (구현 예정)
→ 현재는 태그 등록 기능까지만 구현되어 있으며, 사용자는 이렇게 등록된 태그 목록을 조회하고, 프로필에 태그를 추가할 수 있음

- 태그 등록 시:
  - 태그 이름은 10자 이내로 제한 (`IllegalArgumentException` 처리)
  - 태그 색상 코드도 함께 저장
  - 태그 이름 중복 시 `DuplicateTagException` 예외 발생

### 2. 사용자 인증 및 권한 검증
- 현재 로그인한 사용자와 URI 상의 `userId` 일치 여부 검증
- 일치하지 않을 경우 `NotUserEqualsCurrentUserException` 예외 발생

```java
userEqualsCurrentUser(userId, getCurrentUserId(authentication));
```

### 3. 태그 삭제 로직
- 특정 태그 삭제 시 다음 절차 수행:
	1.	ProfileTag 삭제
	2.	동일 유저가 다른 곳에서 해당 태그를 사용하는지 확인
	3.	참조가 없을 경우 Tag 자체 삭제
- 사용자가 만든 개인 태그는 공유되지 않으므로 소프트 삭제가 아닌 물리 삭제 방식 사용
```
profileTagRepository.delete(targetDeleteTag);
if (!isUsedElsewhere) {
    tagRepository.delete(tag);
}
```
### 4. 태그 수정 로직
- 기존 태그에서 이름, 색상 등을 수정 가능
- 새로운 이름이 기존 사용자 태그와 중복되는 경우 예외 발생
- ProfileTagUpdateRequest, ProfileTagRequest에 공통 인터페이스 HasTagName을 도입하여 중복 로직 제거
