### PR TITLE
[Feat] 사용자 프로필에 태그(기술스택) 표시 기능 구현

### DIFF
--- a/src/main/java/org/spring/dojooo/global/ErrorCode.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorCode.java
@@ -42,13 +42,15 @@ public enum ErrorCode {
 
     //프로필
     WRONG_USER_EDIT("본인의 프로필만 수정할 수 있습니다.",403),
+    MAX_REGISTER_TAG_EXCEPTION("최대 5개의 테그만 등록이 가능합니다",400),
 
     //메모
     DUPLICATE_MEMO_HEADER("이미 사용중인 제목입니다. 다른 제목으로 작성해주세요",400),
 
     //테그 관련
     DUPLICATE_TAG_EXCEPTION("이미 등록된 테그입니다",400),
-    NOTFOUND_TAG_EXCEPTION("테그를 찾을 수 없습니다",404);
+    NOTFOUND_TAG_EXCEPTION("테그를 찾을 수 없습니다",404),
+    MAX_TAG_LENGTH_EXCEPTION("테그는 10자 이내로 작성할 수 있습니다",400);
 
 
 

--- a/src/main/java/org/spring/dojooo/global/ErrorResponse.java
+++ b/src/main/java/org/spring/dojooo/global/ErrorResponse.java
@@ -26,6 +26,7 @@ public class ErrorResponse {
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode);
     }
+
     public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
         return new ErrorResponse(errorCode, FieldError.of(bindingResult));
     }

--- a/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
+++ b/src/main/java/org/spring/dojooo/global/GlobalExceptionHandler.java
@@ -83,5 +83,11 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
         return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
     }
+    @ExceptionHandler(MaxTegLengthException.class)
+    public ResponseEntity<ErrorResponse> handleMaxTegLengthException(MaxTegLengthException exception) {
+        log.error("handleMaxTegLengthExceptin", exception);
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MAX_TAG_LENGTH_EXCEPTION);
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/domain/Profile.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/Profile.java
@@ -3,6 +3,8 @@ package org.spring.dojooo.main.users.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 
 @Embeddable
 @Getter
@@ -16,4 +18,5 @@ public class Profile {
 
     @Column(columnDefinition = "TEXT")
     private String introduction;
+
 }

--- a/src/main/java/org/spring/dojooo/main/users/domain/User.java
+++ b/src/main/java/org/spring/dojooo/main/users/domain/User.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -64,6 +65,8 @@ public class User {
         this.isDeleted = isDeleted != null ? isDeleted : false;
         this.profile = new Profile(DEFAULT_PROFILE_IMAGE,null); //profileimage = null, introduction = null
 
+
+
     }
     //수정 가능 항목
     enum UpdateInfo {
@@ -107,5 +110,11 @@ public class User {
         this.profile = profile;
     }
 
+    public List<String> getVisibleProfileTagNames() {
+        return this.profileTags.stream()
+                .filter(ProfileTag::isShowOnProfile)
+                .map(pt -> pt.getTag().getTagName())
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
+++ b/src/main/java/org/spring/dojooo/main/users/dto/ProfileDetails.java
@@ -2,6 +2,7 @@ package org.spring.dojooo.main.users.dto;
 
 import lombok.*;
 import org.spring.dojooo.main.users.domain.Profile;
+import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.domain.User;
 
 import java.util.List;
@@ -28,12 +29,12 @@ public class ProfileDetails {
                 .map(Profile::getIntroduction)
                 .orElse("");
 
-
         return ProfileDetails.builder()
                 .id(user.getId())
                 .profileImage(profileImage)
                 .nickname(user.getNickname())
                 .introduction(introduction)
+                .tags(user.getVisibleProfileTagNames())
                 .isMine(isOwner)
                 .build();
     }

--- a/src/main/java/org/spring/dojooo/main/users/exception/MaxTegLengthException.java
+++ b/src/main/java/org/spring/dojooo/main/users/exception/MaxTegLengthException.java
@@ -1,0 +1,10 @@
+package org.spring.dojooo.main.users.exception;
+
+import org.spring.dojooo.global.ErrorCode;
+import org.spring.dojooo.global.exception.BusinessException;
+
+public class MaxTegLengthException extends BusinessException {
+    public MaxTegLengthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
@@ -8,10 +8,7 @@ import org.spring.dojooo.global.repository.TagRepository;
 import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.domain.User;
 import org.spring.dojooo.main.users.dto.*;
-import org.spring.dojooo.main.users.exception.DuplicateTagException;
-import org.spring.dojooo.main.users.exception.NotFoundTagException;
-import org.spring.dojooo.main.users.exception.NotFoundUserException;
-import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
+import org.spring.dojooo.main.users.exception.*;
 import org.spring.dojooo.main.users.repository.ProfileTagRepository;
 import org.spring.dojooo.main.users.repository.UserRepository;
 import org.springframework.security.core.Authentication;
@@ -115,7 +112,7 @@ public class ProfileTagService {
     //테그 10자이상 작성시 Exception
     public void checkTagLength(String tagName) {
         if(tagName.length()>10){
-            throw new IllegalArgumentException("테그는 10자 이내로 작성가능합니다");
+            throw new MaxTegLengthException(ErrorCode.MAX_TAG_LENGTH_EXCEPTION);
         }
     }
     //테그 리스트중에서 조건에 맞는 테그 하나를 찾는 로직

--- a/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/ProfileTagService.java
@@ -130,17 +130,20 @@ public class ProfileTagService {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         return userDetails.getId();
     }
+
     //로그인한 사용자와 정보가 같은지 확인
     public void userEqualsCurrentUser(Long userId, Long currentUserId) {
         if(!userId.equals(currentUserId)) {
             throw new NotUserEqualsCurrentUserException(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
         }
     }
+
     //유저 조회 로직
     public User findCurrentUser(Long userId) {
         User user  = userRepository.findByIdAndIsDeletedFalse(userId).orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
         return user;
     }
+
     //중복 테그인지 아닌지 확인
     public void duplicateTag(User user, HasTagName tagRequest) {
         boolean alreadyRegistered = profileTagRepository.findAllByUser(user).stream()

--- a/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
@@ -5,16 +5,13 @@ import org.spring.dojooo.auth.jwt.dto.CustomUserDetails;
 import org.spring.dojooo.global.ErrorCode;
 import org.spring.dojooo.global.S3.S3FileService;
 import org.spring.dojooo.global.exception.NotFoundException;
-import org.spring.dojooo.global.domain.Tag;
+import org.spring.dojooo.main.users.exception.*;
 import org.spring.dojooo.main.users.domain.Profile;
 import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.domain.User;
 import org.spring.dojooo.main.users.dto.ProfileDetails;
 import org.spring.dojooo.main.users.dto.ProfileUpdateRequest;
 import org.spring.dojooo.main.users.dto.ProfileSaveRequest;
-import org.spring.dojooo.main.users.exception.DuplicateTagException;
-import org.spring.dojooo.main.users.exception.NotFoundTagException;
-import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
 import org.spring.dojooo.main.users.repository.ProfileTagRepository;
 import org.spring.dojooo.main.users.repository.UserRepository;
 import org.springframework.security.core.Authentication;
@@ -69,8 +66,9 @@ public class UserProfileService {
         List<String> selectedTags = profileUpdateRequest.getTagNames();
 
         //5개보다 더 선택한 경우 예외처리
-        if(selectedTags != null && selectedTags.size()>5){
-            throw new IllegalArgumentException("최대 5개의 테그만 선택 가능합니다");}
+        if(selectedTags != null && selectedTags.size()>5) {
+            throw new MaxTegLengthException(ErrorCode.MAX_REGISTER_TAG_EXCEPTION);
+        }
         //현재 등록되어 있는 테그 불러옴
         List<ProfileTag> findAllTags = profileTagRepository.findAllByUser(user);
 

--- a/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
+++ b/src/main/java/org/spring/dojooo/main/users/service/UserProfileService.java
@@ -7,17 +7,23 @@ import org.spring.dojooo.global.S3.S3FileService;
 import org.spring.dojooo.global.exception.NotFoundException;
 import org.spring.dojooo.global.domain.Tag;
 import org.spring.dojooo.main.users.domain.Profile;
+import org.spring.dojooo.main.users.domain.ProfileTag;
 import org.spring.dojooo.main.users.domain.User;
 import org.spring.dojooo.main.users.dto.ProfileDetails;
 import org.spring.dojooo.main.users.dto.ProfileUpdateRequest;
 import org.spring.dojooo.main.users.dto.ProfileSaveRequest;
+import org.spring.dojooo.main.users.exception.DuplicateTagException;
+import org.spring.dojooo.main.users.exception.NotFoundTagException;
 import org.spring.dojooo.main.users.exception.NotUserEqualsCurrentUserException;
+import org.spring.dojooo.main.users.repository.ProfileTagRepository;
 import org.spring.dojooo.main.users.repository.UserRepository;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -28,6 +34,7 @@ public class UserProfileService {
     private final UserRepository userRepository;
     private static final String DEFAULT_PROFILE_IMAGE = "https://dojooo.s3.ap-northeast-2.amazonaws.com/profile/80aefad7-3_%E1%84%80%E1%85%B5%E1%84%87%E1%85%A9%E1%86%AB%E1%84%91%E1%85%B3%E1%84%85%E1%85%A9%E1%84%91%E1%85%B5%E1%86%AF.jpg";
     private final S3FileService s3FileService;
+    private final ProfileTagRepository profileTagRepository;
 
     // 프로필 조회
     @Transactional(readOnly = true)
@@ -39,15 +46,14 @@ public class UserProfileService {
     }
     //프로필 수정
     @Transactional
-    public void editProfile(Long userId, ProfileUpdateRequest profileEditRequest, Authentication authentication) { Long currentUserId = getCurrentUserId(authentication);
+    public void editProfile(Long userId, ProfileUpdateRequest profileUpdateRequest, Authentication authentication) { Long currentUserId = getCurrentUserId(authentication);
 
-        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = userEqualsCurrentUser(userId, authentication);
 
-        User user = findUserById(userId);
         Profile existingProfile = user.getProfile(); //기존(/users/profile/save) 프로필
 
-        String getImageUrl = profileEditRequest.getProfileImageUrl();
-        String getIntroduction = profileEditRequest.getIntroduction();
+        String getImageUrl = profileUpdateRequest.getProfileImageUrl();
+        String getIntroduction = profileUpdateRequest.getIntroduction();
 
         //Null 허용 (사용자가 이미지만, 자기소개만 수정하고 싶을수도 있으니깐)
         String updatedImageUrl = (getImageUrl != null && !getImageUrl.isBlank())
@@ -58,8 +64,39 @@ public class UserProfileService {
 
         String updatedIntroduction = (getIntroduction != null) ? getIntroduction : (existingProfile != null ? existingProfile.getIntroduction() : null);
 
+        //프로필 테그 등록 기능 구현
+        //is_shown_on Ture - True
+        List<String> selectedTags = profileUpdateRequest.getTagNames();
+
+        //5개보다 더 선택한 경우 예외처리
+        if(selectedTags != null && selectedTags.size()>5){
+            throw new IllegalArgumentException("최대 5개의 테그만 선택 가능합니다");}
+        //현재 등록되어 있는 테그 불러옴
+        List<ProfileTag> findAllTags = profileTagRepository.findAllByUser(user);
 
 
+        Set<String> existingTagNames = findAllTags.stream()
+                .map(tag -> tag.getTag().getTagName())
+                .collect(Collectors.toSet());
+
+        if(selectedTags != null && selectedTags.size()<= 5){
+            //중복 검사 - HashSet (중복을 허용하지않음) - HashSet Size하고 기존 선택 테그 리스트 Size 비교했을때, 다르면 중복이 있는거
+            if(selectedTags.size() != new HashSet<>(selectedTags).size()){
+                throw new DuplicateTagException(ErrorCode.DUPLICATE_TAG_EXCEPTION);
+            }
+            //존재 여부 검사
+            for(String selectedTagName : selectedTags){
+                if(!existingTagNames.contains(selectedTagName)){
+                    throw new NotFoundTagException(ErrorCode.NOTFOUND_TAG_EXCEPTION);
+                }
+            }
+        }
+
+        for(ProfileTag profileTag : findAllTags) {
+            String tagName = profileTag.getTag().getTagName();
+            boolean showOnProfile = selectedTags != null && selectedTags.contains(tagName);
+            profileTag.settingShowOnProfile(showOnProfile);
+        }
 
         Profile updatedprofile = Profile.builder()
                 .profileImage(updatedImageUrl)
@@ -76,9 +113,7 @@ public class UserProfileService {
     @Transactional
     public void saveProfile(Long userId, ProfileSaveRequest profileSaveRequest, Authentication authentication) {
 
-        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
-
-        User user = findUserById(userId);
+        User user = userEqualsCurrentUser(userId, authentication);
 
         String imageUrl = profileSaveRequest.getProfileImageUrl();
         if (imageUrl == null || imageUrl.isBlank()) {
@@ -92,31 +127,12 @@ public class UserProfileService {
         user.updateProfile(profile);
     }
 
-    // 로그인한 사용자 ID 추출
-    private Long getCurrentUserId(Authentication authentication) {
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        return userDetails.getId();
-    }
-
-    //로그인한 사용자와 정보가 같은지 확인
-    public Long userEqualsCurrentUser(Long userId, Long currentUserId) {
-        if(!userId.equals(currentUserId)) {
-            throw new NotUserEqualsCurrentUserException(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
-        }
-        return userId;
-    }
-
-    // 사용자 조회
-    private User findUserById(Long userId) {
-        return userRepository.findByIdAndIsDeletedFalse(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
-    }
-
     //프로필 초기화
     @Transactional
     public void resetProfile(Long userId, Authentication authentication){
-        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
-        User user = findUserById(userId);
+
+        User user = userEqualsCurrentUser(userId, authentication);
+
         //기존 이미지가 Default 이미지(기본 이미지) 가 아닌 등록한 이미지인경우 S3에 등록이미지 제거
         String currentImageUrl = user.getProfile().getProfileImage();
         if (currentImageUrl != null && !DEFAULT_PROFILE_IMAGE.equals(currentImageUrl)) {
@@ -135,6 +151,31 @@ public class UserProfileService {
         user.updateProfile(resetProfile);
         log.info("User {} reset profile.", userId);
 
-
     }
+    // 로그인한 사용자 ID 추출
+    private Long getCurrentUserId(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getId();
+    }
+
+    //로그인한 사용자와 정보가 같은지 확인
+    public Long userEqualsCurrentUser(Long userId, Long currentUserId) {
+        if(!userId.equals(currentUserId)) {
+            throw new NotUserEqualsCurrentUserException(ErrorCode.NOT_USER_EQUALS_CURRENTUSER);
+        }
+        return userId;
+    }
+
+    public User userEqualsCurrentUser(Long userId,Authentication authentication) {
+        userEqualsCurrentUser(getCurrentUserId(authentication), userId);
+        User user = findUserById(userId);
+        return user;
+    }
+
+    // 사용자 조회
+    private User findUserById(Long userId) {
+        return userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_USER));
+    }
+
 }


### PR DESCRIPTION
## 사용자 프로필에 태그(기술스택) 표시 기능 구현

###  목적
- 사용자 프로필에 기술스택을 표시함으로써, 다른 유저가 해당 사용자의 기술 능력을 한눈에 파악할 수 있도록 함
- 이후 구현할 커뮤니케이션 기능(채팅, 프로젝트 제안 등)을 고려하여, 유저의 기술 스택을 기반으로 매칭 및 연결이 가능하도록 기반을 마련

---

###  주요 기능
- 사용자는 **프로필 수정 시** 기존에 등록한 태그 중에서 **최대 5개까지** 선택하여 기술 스택으로 등록할 수 있음
- 태그 등록 시 중복 또는 5개 초과인 경우 예외가 발생하며, 400 Bad Request로 응답

#### 예외 응답 예시 (태그 6개 등록 시):
```json
{
  "message": "최대 5개의 테그만 등록이 가능합니다",
  "status": 400,
  "errors": []
}
```
#### 정상 응답 예시 (태그 5개 등록 시):
```json
{
  "status": 200,
  "message": "요청이 성공적으로 처리되었습니다",
  "data": {
    "id": 1,
    "profileImage": "https://...png",
    "nickname": "yeong",
    "introduction": "소개글",
    "isMine": true,
    "tags": ["Java", "C", "Python", "Spring", "Redis"]
  }
}
```